### PR TITLE
Improves support for comments

### DIFF
--- a/grammars/cucumber plain text feature.cson
+++ b/grammars/cucumber plain text feature.cson
@@ -45,12 +45,16 @@
     'match': '\\s*(#.*)'
   'table':
     'begin': '^\\s*\\|'
-    'end': '\\|\\s*$'
+    'end': '(\\|\\s*$|^\\n$)'
     'name': 'keyword.control.cucumber.table'
     'patterns': [
       {
         'match': '\\.'
         'name': 'source'
+      }
+      {
+        'match': '\\s*\\#[^|]*$'
+        'name': 'comment.line.number-sign'
       }
     ]
   'feature_keyword':

--- a/grammars/cucumber plain text feature.cson
+++ b/grammars/cucumber plain text feature.cson
@@ -45,7 +45,7 @@
     'match': '\\s*(#.*)'
   'table':
     'begin': '^\\s*\\|'
-    'end': '(\\|\\s*$|^\\n$)'
+    'end': '(\\|\\s*$|^\\n\\s*$)'
     'name': 'keyword.control.cucumber.table'
     'patterns': [
       {


### PR DESCRIPTION
Adds support for comments after scenario outline example table rows
Changes how the end of scenario outline example tables are detected

# Comments
I couldn't get it to work with syntax highlighting the comments and table rows correctly with the current definition of the example tables. It either counted the whole line, including the comment, as the table or incorrectly marked everything after as part of the table if you had a comment after the last line of the example table.

Since comments are allowed like this, and I use them to comment rows in examples, I thought it would be nice if the syntax highlighting worked as well.

# Known issues
If you have an example table directly followed by a new scenario, without a blank line in between, it won't work.